### PR TITLE
Added load and save config options.

### DIFF
--- a/.idea/pi_control.iml
+++ b/.idea/pi_control.iml
@@ -8,6 +8,7 @@
       <excludeFolder url="file://$MODULE_DIR$/docs" />
       <excludeFolder url="file://$MODULE_DIR$/legacy" />
       <excludeFolder url="file://$MODULE_DIR$/original" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.6 (pi_control)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/libs/hal.py
+++ b/src/libs/hal.py
@@ -173,6 +173,7 @@ class _ADS1115(ADS1115):
         """
         return level * self.step_size
 
+    # https://github.com/an-oreo/pi_control/issues/7
     def voltage2level(self, voltage: float) -> int:  # todo: check if round or int division
         return round(voltage / self.step_size)
 
@@ -217,6 +218,7 @@ class _MCP4725(MCP4725):
         """
         return level * self.step_size
 
+    # https://github.com/an-oreo/pi_control/issues/7
     def voltage2level(self, voltage: float) -> int:  # todo: check if round or int division
         return round(voltage / self.step_size)
 
@@ -276,7 +278,7 @@ class Actuator:
     @wrap_dict_ts(('force', 'local_temp', 'timestamp'))
     def load(self) -> Tuple:
         load = self.force_sensor.get_reading()
-        return load  # guaranteed random todo: work on implementing this
+        return load
 
     @property
     @wrap_dict_ts(('speed',))
@@ -304,6 +306,7 @@ class Actuator:
 
     # will require speed vs voltage information
     # todo: get data for speed vs voltage info
+    # https://github.com/an-oreo/pi_control/issues/9
     def set_out_speed(self, speed) -> None:
         raise NotImplementedError('no information known for this')
 

--- a/src/libs/max31856.py
+++ b/src/libs/max31856.py
@@ -262,8 +262,6 @@ class MAX31856(object):
 
     def read_fault_register(self):
         """Return bytes containing fault codes and hardware problems.
-
-        TODO: Could update in the future to return human readable values
         """
         reg = self._read_register(self.MAX31856_REG_READ_FAULT)
         return reg

--- a/src/libs/sparkfun_openscale.py
+++ b/src/libs/sparkfun_openscale.py
@@ -11,11 +11,16 @@ License: N/A
 Description: library for interfacing the Sparkfun OpenScale.
 """
 
+import os
+import yaml
 import serial
+from os.path import join as ospjoin
 from typing import Tuple, Dict, Union
 
 
 # todo: get some form of config dumping and loading implemented
+# https://github.com/an-oreo/pi_control/issues/10
+CFG_FILE_PATH = ospjoin(os.environ.get('OPENSCALE_CFG_PATH', '../../CONFIGS/'), 'openscale_cfg.yml')
 
 
 class OpenScale(serial.Serial):
@@ -538,3 +543,39 @@ class OpenScale(serial.Serial):
             return reading * 9.80665  # returns N
         else:
             return reading * 32.174049  # returns lbf
+
+    def save_config(self):
+        data = {
+            'tare': self._tare_val,
+            'calibrate': self._cal_value,
+            'timestamp_enable': self._timestamp_enable,
+            'report_rate': self._report_rate,
+            'units': self._units,
+            'decimal_places': self._decimal_places,
+            'num_avgs': self._num_avgs,
+            'local_temp_enable': self._local_temp_enable,
+            'remote_temp_enable': self._remote_temp_enable,
+            'status_led': self._status_led,
+            'trigger_enable': self._serial_trigger_enable,
+            'raw_read_enable': self._raw_reading_enable,
+            'trigger_char': self._trigger_char,
+        }
+        with open(CFG_FILE_PATH, 'w') as file:
+            file.write(yaml.dump(data))
+
+    def load_config(self):
+        with open(CFG_FILE_PATH, 'r') as file:
+            data = yaml.dump(file.read())
+        self._tare_val = data['tare']
+        self._cal_value = data['calibrate']
+        self._timestamp_enable = data['timestamp_enable']
+        self._report_rate = data['report_rate']
+        self._units = data['units']
+        self._decimal_places = data['decimal_places']
+        self._num_avgs = data['num_avgs']
+        self._local_temp_enable = data['local_temp_enable']
+        self._remote_temp_enable = data['remote_temp_enable']
+        self._status_led = data['status_led']
+        self._serial_trigger_enable = data['trigger_enable']
+        self._raw_reading_enable = data['raw_read_enable']
+        self._trigger_char = data['trigger_char']

--- a/src/orchestration/procedure.py
+++ b/src/orchestration/procedure.py
@@ -25,6 +25,7 @@ from orchestration.routines import Routine
 
 
 # TODO: figure out validation -- looks like have to define a method in the from_yaml hook
+# https://github.com/an-oreo/pi_control/issues/6
 class Config(BaseYamlConstruct):
     yaml_tag = '!Config'
     type = 'CFG'


### PR DESCRIPTION
Will search for an env var labeled `OPENSCALE_CFG_PATH` expecting a path to a directory. If not found it will default to a path of: `../../CONFIGS/`. If will then perform a check whetehr the path exists. make directories if needed, and will use the file named `openscale_cfg.yml` to load/store from.
On stores, all previous content will be wiped and overwritten. Values are stored in plaintext YAML allowing for user configurability if needed.

solves #10 

Signed-off-by: Danyal Ahsanullah <dahsanul@iastate.edu>